### PR TITLE
Create harbour-seachest-sv.ts

### DIFF
--- a/translations/harbour-seachest-sv.ts
+++ b/translations/harbour-seachest-sv.ts
@@ -1,0 +1,195 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sv">
+<context>
+    <name>About</name>
+    <message>
+        <source>About</source>
+        <translation>Om</translation>
+    </message>
+    <message>
+        <source>An unofficial Dropbox client for Sailfish OS.
+
+by Michael J. Barrett
+mjeb.dev
+
+Version 0.1
+Licensed under GNU GPLv3</source>
+        <translation>En inofficiell Dropbox-klient för Sailfish OS.
+
+av Michael J. Barrett
+mjeb.dev
+
+Version 0.1
+Licensierad under GNU GPLv3</translation>
+    </message>
+</context>
+<context>
+    <name>Authorize</name>
+    <message>
+        <source>Authorize SeaChest</source>
+        <translation>Auktorisera SeaChest</translation>
+    </message>
+    <message>
+        <source>Authorization Successful</source>
+        <translation>Auktorisation slutförd</translation>
+    </message>
+</context>
+<context>
+    <name>Home</name>
+    <message>
+        <source>Reauthorized</source>
+        <translation>Återauktoriserad</translation>
+    </message>
+    <message>
+        <source>Error reauthorizing. Please try resubmitting your request.</source>
+        <translation>Det gick inte att auktorisera om. Försök att skicka begäran igen.</translation>
+    </message>
+    <message>
+        <source>Bad input parameter. Error copied.</source>
+        <translation>Felaktig indataparameter. Felet har kopierats.</translation>
+    </message>
+    <message>
+        <source>Refresh</source>
+        <translation>Uppdatera</translation>
+    </message>
+    <message>
+        <source>About</source>
+        <translation>Om</translation>
+    </message>
+    <message>
+        <source>Settings</source>
+        <translation>Inställningar</translation>
+    </message>
+    <message>
+        <source>Home</source>
+        <translation>Hem</translation>
+    </message>
+    <message>
+        <source>Upload in progress</source>
+        <translation>Uppladdning pågår</translation>
+    </message>
+    <message>
+        <source>Upload</source>
+        <translation>Ladda upp</translation>
+    </message>
+    <message>
+        <source>Error refreshing token: </source>
+        <translation>Fel vid uppdatering av token: </translation>
+    </message>
+    <message>
+        <source>Access to this feature was denied.</source>
+        <translation>Åtkomst till den här funktionen nekades.</translation>
+    </message>
+    <message>
+        <source>Endpoint-specific error. Error copied to clipboard.</source>
+        <translation>Slutpunktsspecifikt fel. Felet kopierades till Urklipp.</translation>
+    </message>
+    <message>
+        <source>Too many requests.</source>
+        <translation>För många förfrågningar.</translation>
+    </message>
+    <message>
+        <source>Error saving thumbnail to cache folder.</source>
+        <translation>Det gick inte att spara miniatyrbilden i cachemappen.</translation>
+    </message>
+    <message>
+        <source>Modified on server:</source>
+        <translation>Ändrad på servern:</translation>
+    </message>
+    <message>
+        <source>Modified on client:</source>
+        <translation>Ändrad på klienten:</translation>
+    </message>
+    <message>
+        <source>Size:</source>
+        <translation>Storlek:</translation>
+    </message>
+    <message>
+        <source> bytes</source>
+        <translation> byte</translation>
+    </message>
+    <message>
+        <source>Open</source>
+        <translation>Öppna</translation>
+    </message>
+    <message>
+        <source>Download</source>
+        <translation>Ladda ner</translation>
+    </message>
+    <message>
+        <source>Rename</source>
+        <translation>Byt namn</translation>
+    </message>
+    <message>
+        <source>Delete Folder</source>
+        <translation>Ta bort mapp</translation>
+    </message>
+    <message>
+        <source>Delete File</source>
+        <translation>Ta bort fil</translation>
+    </message>
+</context>
+<context>
+    <name>Settings</name>
+    <message>
+        <source>Settings</source>
+        <translation>Inställningar</translation>
+    </message>
+    <message>
+        <source>Interface</source>
+        <translation>Gränssnitt</translation>
+    </message>
+    <message>
+        <source>Action to download file</source>
+        <translation>Åtgärd för att ladda ner fil</translation>
+    </message>
+    <message>
+        <source>Press &amp; hold for other options</source>
+        <translation>Långtryck för andra alternativ</translation>
+    </message>
+    <message>
+        <source>Show warning prior to overwriting an identically named file in Downloads</source>
+        <translation>Visa varning innan en fil med samma namn skrivs över i Nedladdningar</translation>
+    </message>
+    <message>
+        <source>Tap for other options</source>
+        <translation>Tryck för andra alternativ</translation>
+    </message>
+    <message>
+        <source>Tap</source>
+        <translation>Tryck</translation>
+    </message>
+    <message>
+        <source>Press &amp; hold</source>
+        <translation>Långtryck</translation>
+    </message>
+    <message>
+        <source>Authorization</source>
+        <translation>Auktorisering</translation>
+    </message>
+    <message>
+        <source>Erase Access Key</source>
+        <translation>Radera åtkomstnyckel</translation>
+    </message>
+</context>
+<context>
+    <name>harbour-seachest</name>
+    <message>
+        <source>Home</source>
+        <translation>Hem</translation>
+    </message>
+    <message>
+        <source>Error reauthorizing. Please try submitting request again.</source>
+        <translation>Det gick inte att auktorisera om. Försök att skicka begäran igen.</translation>
+    </message>
+    <message>
+        <source>Uploading </source>
+        <translation>Laddar upp </translation>
+    </message>
+    <message>
+        <source>Downloading </source>
+        <translation>Laddar ner </translation>
+    </message>
+</context>
+</TS>

--- a/translations/harbour-seachest.ts
+++ b/translations/harbour-seachest.ts
@@ -143,6 +143,10 @@ Licensed under GNU GPLv3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Show warning prior to overwriting an identically named file in Downloads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Tap for other options</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
Add Swedish translation.

I also added the missing string from Settings.qml, line 77 `"Show warning prior to overwriting an identically named file in Downloads"`.

I didn't investigate why, but you might want to know that the About page isn't translating in the app.